### PR TITLE
Fix types for argv and glob

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -10,12 +10,12 @@ export interface ElectronReloadOptions extends WatchOptions {
      * Arguments passed to the electron binary (relevant for hard
      * resets).
      */
-    electronArgv?: [string],
+    electronArgv?: string[],
     /**
      * Arguments passed to the application (relevant for hard
      * resets).
      */
-    appArgv?: [string]
+    appArgv?: string[]
     /**
      * Determines how to terminate electron in case of hard resets.
      * See 'https://www.electronjs.org/docs/api/app' for details.

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -28,4 +28,4 @@ export interface ElectronReloadOptions extends WatchOptions {
     forceHardReset?: boolean
 }
 
-export default function electronReload(glob: string, options: ElectronReloadOptions) : void;
+export default function electronReload(glob: string | readonly string[], options: ElectronReloadOptions) : void;


### PR DESCRIPTION
Fixes yan-foto/electron-reload#110 and yan-foto/electron-reload#114.

- Fix `electronArgv` and `appArgv` types changed to array instead tuple.
- Allow readonly string array in `glob`.