### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just initialize this module with desired glob or file path to watch and let it r
 
 const {app, BrowserWindow} = require('electron');
 
-const electronReload = require('electron-reload');
+const electronReload = require('@millyc/electron-reload');
 
 // Standard stuff
 app.on('ready', () => {
@@ -45,7 +45,7 @@ If your app overrides some of the default `quit` or `close` actions (e.g. closin
 ```js
 const path = require('path');
 
-require('electron-reload')(__dirname, {
+require('@millyc/electron-reload')(__dirname, {
   electron: path.join(__dirname, 'node_modules', '.bin', 'electron'),
   hardResetMethod: 'exit',
 });

--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ Simply put, I was tired and confused by all other available modules which are so
 \* *e.g. start a local HTTP server, publish change events through a WebSocket, etc.!*
 
 # Changelog
- - **3.0.0**:
-   - Initial release of `@millyc/electron-reload` package.
-   - Forked from [electron-reload v2.0.0-alpha.1](https://github.com/yan-foto/electron-reload/tree/v2.0.0-alpha.1).
-   - Update dependencies.
-   - Fix yan-foto/electron-reload#110: Changed `electronArgv` and `appArgv` types to array.
-   - Fix yan-foto/electron-reload#114: Allow readonly string array in `glob`.
-   - Fix #4: Add JSDoc to `electronReload()`.
+- **3.0.0**:
+  - Fix #9: Support webpack.
+- **3.0.0-alpha.0**:
+  - Initial release of `@millyc/electron-reload` package.
+  - Forked from [electron-reload v2.0.0-alpha.1](https://github.com/yan-foto/electron-reload/tree/v2.0.0-alpha.1).
+  - Update dependencies.
+  - Fix yan-foto/electron-reload#110: Changed `electronArgv` and `appArgv` types to array.
+  - Fix yan-foto/electron-reload#114: Allow readonly string array in `glob`.
+  - Fix #4: Add JSDoc to `electronReload()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@millyc/electron-reload",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@millyc/electron-reload",
-      "version": "3.0.0-alpha.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lint": "standard",
     "lint:fix": "standard --fix"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Milly/electron-reload.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@millyc/electron-reload",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "description": "Simplest way to reload an electron app on file changes!",
   "main": "main.js",
   "types": "./types/main.d.ts",


### PR DESCRIPTION
### Changes [electron-reload v2.0.0-alpha.1][] ... [@millyc/electron-reload v3.0.0][]
- Initial release of `@millyc/electron-reload` package.
- Forked from [electron-reload v2.0.0-alpha.1][].
- Update dependencies.
- Fix yan-foto/electron-reload#110: Changed `electronArgv` and `appArgv` types to array.
- Fix yan-foto/electron-reload#114: Allow readonly string array in `glob`.
- Fix #4: Add JSDoc to `electronReload()`.
- Fix #9: Support webpack.

[electron-reload v2.0.0-alpha.1]: https://github.com/yan-foto/electron-reload/tree/v2.0.0-alpha.1
[@millyc/electron-reload v3.0.0]: https://github.com/Milly/electron-reload/tree/v3.0.0